### PR TITLE
Using atRule.source.input.file to resolve urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ body {
 ```js
 var importUrl = require('postcss-import-url');
 var options = {};
-postcss([importUrl(options)]);
+postcss([importUrl(options)])
+    .process(css, {
+		// Define a `from` option to resolve relative @imports to a url
+        from: 'http://example.com/styles.css',
+    });
 ```
 
 See [PostCSS](https://github.com/postcss/postcss#usage) docs for examples for your environment.
@@ -37,8 +41,8 @@ See [PostCSS](https://github.com/postcss/postcss#usage) docs for examples for yo
 * `userAgent` (string) Custom user-agent header (default: `null`)
 
 ## Known Issues
-* Google fonts returns different file types per the user agent. Because postcss runs in a shell, 
-Google returns truetype fonts rather than the better woff2 format.  
+* Google fonts returns different file types per the user agent. Because postcss runs in a shell,
+Google returns truetype fonts rather than the better woff2 format.
 Use option `modernBrowser` to explicitly load woff2 fonts.
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ var importUrl = require('postcss-import-url');
 var options = {};
 postcss([importUrl(options)])
     .process(css, {
-		// Define a `from` option to resolve relative @imports to a url
+        // Define a `from` option to resolve relative @imports in the initial css to a url.
         from: 'http://example.com/styles.css',
     });
 ```

--- a/test/tangerine.txt
+++ b/test/tangerine.txt
@@ -2,5 +2,5 @@
     font-family: 'Tangerine';
     font-style: normal;
     font-weight: 400;
-    src: local('Tangerine'), url(http://fonts.gstatic.com/s/tangerine/v7/HGfsyCL5WASpHOFnouG-RKCWcynf_cDxXwCLxiixG1c.ttf) format('truetype')
+    src: local('Tangerine Regular'), local('Tangerine-Regular'), url(http://fonts.gstatic.com/s/tangerine/v9/HGfsyCL5WASpHOFnouG-RKCWcynf_cDxXwCLxiixG1c.ttf) format('truetype')
 }

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,7 @@ var fixture1Css = fs.readFileSync(__dirname + "/fixture-1/style.css", {
 	encoding: "utf8"
 });
 
-var testEqual = function(input, output, opts, done, postcssOptions) {
+var testEqual = function(input, output, opts, postcssOptions, done) {
 	postcss([plugin(opts)]).process(input, postcssOptions).then(function(result) {
 		expect(result.css.trim()).to.eql(output.trim());
 		expect(result.warnings()).to.be.empty;
@@ -21,7 +21,7 @@ var testEqual = function(input, output, opts, done, postcssOptions) {
 	});
 };
 
-var testContains = function(input, value, opts, done, postcssOptions) {
+var testContains = function(input, value, opts, postcssOptions, done) {
 	postcss([plugin(opts)]).process(input, postcssOptions).then(function(result) {
 		expect(result.css).to.contain(value);
 		expect(result.warnings()).to.be.empty;
@@ -35,44 +35,44 @@ describe("import with media queries", function() {
 
 	it("empty", function(done) {
 		var input = "@import 'http://fonts.googleapis.com/css?family=Tangerine'            ;";
-		testEqual(input, outputTangerine, {}, done);
+		testEqual(input, outputTangerine, {}, {}, done);
 	});
 
 	it("only screen", function(done) {
 		var input = "@import 'http://fonts.googleapis.com/css?family=Tangerine' only screen and (color)";
-		testContains(input, "@media only screen and (color)", {}, done);
+		testContains(input, "@media only screen and (color)", {}, {}, done);
 	});
 
 	it("rule with and", function(done) {
 		var input = "@import 'http://fonts.googleapis.com/css?family=Tangerine' screen and (orientation:landscape)";
-		testContains(input, "@media screen and (orientation:landscape)", {}, done);
+		testContains(input, "@media screen and (orientation:landscape)", {}, {}, done);
 	});
 
 	it("rule projection, tv", function(done) {
 		var input = "@import url('http://fonts.googleapis.com/css?family=Tangerine') projection, tv";
-		testContains(input, "@media projection, tv", {}, done);
+		testContains(input, "@media projection, tv", {}, {}, done);
 	});
 
 	it("rule print", function(done) {
 		var input = "@import url('http://fonts.googleapis.com/css?family=Tangerine') print";
-		testContains(input, "@media print", {}, done);
+		testContains(input, "@media print", {}, {}, done);
 	});
 
 	it("contains it", function(done) {
 		var input = "@import url('http://fonts.googleapis.com/css?family=Tangerine') (min-width: 25em);";
-		testContains(input, "(min-width: 25em)", {}, done);
+		testContains(input, "(min-width: 25em)", {}, {}, done);
 	});
 
 	describe("media query", function() {
 
 		it("contains font-family", function(done) {
 			var input = "@import url('http://fonts.googleapis.com/css?family=Tangerine') (min-width: 25em);";
-			testContains(input, "font-family: 'Tangerine'", {}, done);
+			testContains(input, "font-family: 'Tangerine'", {}, {}, done);
 		});
 
 		it("contains src local", function(done) {
 			var input = "@import url('http://fonts.googleapis.com/css?family=Tangerine') (min-width: 25em);";
-			testContains(input, "src: local('Tangerine Regular')", {}, done);
+			testContains(input, "src: local('Tangerine Regular')", {}, {}, done);
 		});
 	});
 
@@ -81,17 +81,17 @@ describe("import with media queries", function() {
 describe("skip non remote files", function() {
 
 	it("local", function(done) {
-		testEqual("@import 'a.css';", "@import 'a.css';", {}, done);
+		testEqual("@import 'a.css';", "@import 'a.css';", {}, {}, done);
 	});
 
 	it("relative parent", function(done) {
 		var input = "@import '../a.css'";
-		testEqual(input, input, {}, done);
+		testEqual(input, input, {}, {}, done);
 	});
 
 	it("relative child", function(done) {
 		var input = "@import './a/b.css'";
-		testEqual(input, input, {}, done);
+		testEqual(input, input, {}, {}, done);
 	});
 
 	// it("no protocol", function(done) {
@@ -104,27 +104,27 @@ describe("import url tangerine", function() {
 
 	it("double quotes", function(done) {
 		var input = "@import \"http://fonts.googleapis.com/css?family=Tangerine\";";
-		testEqual(input, outputTangerine, {}, done);
+		testEqual(input, outputTangerine, {}, {}, done);
 	});
 
 	it("single quotes", function(done) {
 		var input = "@import 'http://fonts.googleapis.com/css?family=Tangerine';";
-		testEqual(input, outputTangerine, {}, done);
+		testEqual(input, outputTangerine, {}, {}, done);
 	});
 
 	it("url single quotes", function(done) {
 		var input = "@import url('http://fonts.googleapis.com/css?family=Tangerine');";
-		testEqual(input, outputTangerine, {}, done);
+		testEqual(input, outputTangerine, {}, {}, done);
 	});
 
 	it("url double quotes", function(done) {
 		var input = "@import url(\"http://fonts.googleapis.com/css?family=Tangerine\");";
-		testEqual(input, outputTangerine, {}, done);
+		testEqual(input, outputTangerine, {}, {}, done);
 	});
 
 	it("url no quotes", function(done) {
 		var input = "@import url(http://fonts.googleapis.com/css?family=Tangerine);";
-		testEqual(input, outputTangerine, {}, done);
+		testEqual(input, outputTangerine, {}, {}, done);
 	});
 
 });
@@ -145,24 +145,24 @@ describe("recursive import", function() {
 
 		it("fixture-1 contains class a1", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-1/style.css)';
-			testContains(input, 'content: ".a1"', opts, done);
+			testContains(input, 'content: ".a1"', opts, {}, done);
 		});
 
 		it("fixture-1 contains class a", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-1/style.css)';
-			testContains(input, 'content: ".a"', opts, done);
+			testContains(input, 'content: ".a"', opts, {}, done);
 		});
 
 		it("fixture-1 contains class style content", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-1/style.css)';
-			testContains(input, 'content: ".style"', opts, done);
+			testContains(input, 'content: ".style"', opts, {}, done);
 		});
 
 		it("fixture-1 contains class a when passed as a string", function(done) {
 			var input = fixture1Css;
-			testContains(input, 'content: ".a"', opts, done, {
+			testContains(input, 'content: ".a"', opts, {
 				from: 'http://localhost:1234/fixture-1/style.css',
-			});
+			}, done);
 		});
 	});
 
@@ -170,27 +170,27 @@ describe("recursive import", function() {
 
 		it("fixture-2 contains class a1", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-2/style.css)';
-			testContains(input, 'content: ".a1"', opts, done);
+			testContains(input, 'content: ".a1"', opts, {}, done);
 		});
 
 		it("fixture-2 contains class a", function(done) {
 			var input = "@import url(http://localhost:1234/fixture-2/style.css)";
-			testContains(input, 'content: ".a"', opts, done);
+			testContains(input, 'content: ".a"', opts, {}, done);
 		});
 
 		it("fixture-2 contains class b1", function(done) {
 			var input = "@import url(http://localhost:1234/fixture-2/style.css)";
-			testContains(input, 'content: ".b1"', opts, done);
+			testContains(input, 'content: ".b1"', opts, {}, done);
 		});
 
 		it("fixture-2 contains class b", function(done) {
 			var input = "@import url(http://localhost:1234/fixture-2/style.css)";
-			testContains(input, 'content: ".b"', opts, done);
+			testContains(input, 'content: ".b"', opts, {}, done);
 		});
 
 		it("fixture-2 contains class style content", function(done) {
 			var input = "@import url(http://localhost:1234/fixture-2/style.css)";
-			testContains(input, 'content: ".style"', opts, done);
+			testContains(input, 'content: ".style"', opts, {}, done);
 		});
 	});
 
@@ -200,13 +200,13 @@ describe("google font woff", function() {
 
 	it("option modernBrowser should import woff", function(done) {
 		var input = "@import url(http://fonts.googleapis.com/css?family=Tangerine);";
-		testContains(input, "woff2) format('woff2')", {modernBrowser: true}, done);
+		testContains(input, "woff2) format('woff2')", {modernBrowser: true}, {}, done);
 	});
 
 	it("option agent should import woff", function(done) {
 		var input = "@import url(http://fonts.googleapis.com/css?family=Tangerine);";
 		var opts = {userAgent: 'Mozilla/5.0 AppleWebKit/537.36 Chrome/54.0.2840.99 Safari/537.36'};
-		testContains(input, "woff2) format('woff2')", opts, done);
+		testContains(input, "woff2) format('woff2')", opts, {}, done);
 	});
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ var outputTangerine = fs.readFileSync(__dirname + "/tangerine.txt", {
 
 var testEqual = function(input, output, opts, done) {
 	postcss([plugin(opts)]).process(input).then(function(result) {
-		expect(result.css).to.eql(output);
+		expect(result.css.trim()).to.eql(output.trim());
 		expect(result.warnings()).to.be.empty;
 		done();
 	}).catch(function(error) {
@@ -69,7 +69,7 @@ describe("import with media queries", function() {
 
 		it("contains src local", function(done) {
 			var input = "@import url('http://fonts.googleapis.com/css?family=Tangerine') (min-width: 25em);";
-			testContains(input, "src: local('Tangerine')", {}, done);
+			testContains(input, "src: local('Tangerine Regular')", {}, done);
 		});
 	});
 
@@ -92,7 +92,7 @@ describe("skip non remote files", function() {
 	});
 
 	// it("no protocol", function(done) {
-	// 	var input = "@import url(//example.com/a.css)"; 
+	// 	var input = "@import url(//example.com/a.css)";
 	// 	test(input, input, {}, done);
 	// });
 });
@@ -192,7 +192,7 @@ describe("google font woff", function() {
 		var input = "@import url(http://fonts.googleapis.com/css?family=Tangerine);";
 		testContains(input, "woff2) format('woff2')", {modernBrowser: true}, done);
 	});
-	
+
 	it("option agent should import woff", function(done) {
 		var input = "@import url(http://fonts.googleapis.com/css?family=Tangerine);";
 		var opts = {userAgent: 'Mozilla/5.0 AppleWebKit/537.36 Chrome/54.0.2840.99 Safari/537.36'};

--- a/test/test.js
+++ b/test/test.js
@@ -7,9 +7,12 @@ var tcpp = require('tcp-ping');
 var outputTangerine = fs.readFileSync(__dirname + "/tangerine.txt", {
 	encoding: "utf8"
 });
+var fixture1Css = fs.readFileSync(__dirname + "/fixture-1/style.css", {
+	encoding: "utf8"
+});
 
-var testEqual = function(input, output, opts, done) {
-	postcss([plugin(opts)]).process(input).then(function(result) {
+var testEqual = function(input, output, opts, done, postcssOptions) {
+	postcss([plugin(opts)]).process(input, postcssOptions).then(function(result) {
 		expect(result.css.trim()).to.eql(output.trim());
 		expect(result.warnings()).to.be.empty;
 		done();
@@ -18,8 +21,8 @@ var testEqual = function(input, output, opts, done) {
 	});
 };
 
-var testContains = function(input, value, opts, done) {
-	postcss([plugin(opts)]).process(input).then(function(result) {
+var testContains = function(input, value, opts, done, postcssOptions) {
+	postcss([plugin(opts)]).process(input, postcssOptions).then(function(result) {
 		expect(result.css).to.contain(value);
 		expect(result.warnings()).to.be.empty;
 		done();
@@ -129,7 +132,7 @@ describe("import url tangerine", function() {
 describe("recursive import", function() {
 
 	it('ping server', (done) => {
-		tcpp.probe('localhost', 1234, function(err, available) {
+		tcpp.probe('localhost', 1234, function(err) {
 			done(err);
 		});
 	});
@@ -153,6 +156,13 @@ describe("recursive import", function() {
 		it("fixture-1 contains class style content", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-1/style.css)';
 			testContains(input, 'content: ".style"', opts, done);
+		});
+
+		it("fixture-1 contains class a when passed as a string", function(done) {
+			var input = fixture1Css;
+			testContains(input, 'content: ".a"', opts, done, {
+				from: 'http://localhost:1234/fixture-1/style.css',
+			});
 		});
 	});
 


### PR DESCRIPTION
This change allows for relative remote @imports in the initial css.

``` css
/* Downloaded from http://example.com/css/styles.css
@import url(fonts.css)
...
```

With the above css a developer can pass the css source to postcss, with a `from` option, and urls relative urls in the css will be resolved.

``` javascript
var importUrl = require('postcss-import-url');
var options = {};
postcss([importUrl(options)])
    .process(css, {
        // Define a `from` option to resolve relative @imports to a url
        from: 'http://example.com/css/styles.css',
    });
```