### PR TITLE
Upgraded to the latest version of postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "is-url": "^1.2.1",
     "lodash.assign": "^4.0.9",
     "lodash.trim": "^4.4.0",
-    "postcss": "^5.0.2",
+    "postcss": "^6.0.13",
     "resolve-relative-url": "1.0.0"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -8,9 +8,19 @@ var outputTangerine = fs.readFileSync(__dirname + "/tangerine.txt", {
 	encoding: "utf8"
 });
 
+function trimLine(line) {
+	return line.trim();
+}
+
+function trimLines(value) {
+	value.split('\n')
+		.map(trimLine)
+		.join('\n');
+}
+
 var testEqual = function(input, output, opts, done) {
 	postcss([plugin(opts)]).process(input).then(function(result) {
-		expect(result.css.trim()).to.eql(output.trim());
+		expect(trimLines(result.css)).to.eql(trimLines(output));
 		expect(result.warnings()).to.be.empty;
 		done();
 	}).catch(function(error) {


### PR DESCRIPTION
With the upgrade tests were failing because of indentation differences. To resolve this, I updated `testEqual` to compare without taking indentation into consideration.

Resolves #11 