### PR TITLE
feat: Resolve relative URLs in property values

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ See [PostCSS](https://github.com/postcss/postcss#usage) docs for examples for yo
 
 ## Options
 * `recursive` (boolean) To import URLs recursively (default: `true`)
-* `modernBrowser` (boolean) set user-agent string to 'Mozilla/5.0 AppleWebKit/537.36 Chrome/65.0.0.0 Safari/537.36', this option maybe useful for importing fonts from Google. Google check `user-agent` header string and respond can be different (default: `false`)
+* `resolveUrls` (boolean) To transform relative URLs found in remote stylesheets into fully qualified URLs ([see #18](https://github.com/unlight/postcss-import-url/pull/18)) (default: `false`)
+* `modernBrowser` (boolean) Set user-agent string to 'Mozilla/5.0 AppleWebKit/537.36 Chrome/65.0.0.0 Safari/537.36', this option maybe useful for importing fonts from Google. Google check `user-agent` header string and respond can be different (default: `false`)
 * `userAgent` (string) Custom user-agent header (default: `null`)
 
 ## Known Issues

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var resolveRelative = require("resolve-relative-url");
 var assign = require("lodash.assign");
 var defaults = {
 	recursive: true,
+	resolveURLs: false,
 	modernBrowser: false,
 	userAgent: null
 };
@@ -37,10 +38,12 @@ function postcssImportUrl(options) {
 					newNode = mediaNode;
 				}
 
-				// Convert relative paths to absolute paths
-				newNode = newNode.replaceValues(urlRegexp, { fast: 'url(' }, function(url) {
-					return resolveUrls(url, remoteFile);
-				});
+				if (options.resolveUrls) {
+					// Convert relative paths to absolute paths
+					newNode = newNode.replaceValues(urlRegexp, { fast: 'url(' }, function(url) {
+						return resolveUrls(url, remoteFile);
+					});
+				}
 
 				var p = (options.recursive) ? importUrl(newNode, null, r.parent) : Promise.resolve(newNode);
 				return p.then(function(tree) {

--- a/test/fixture-3/a.css
+++ b/test/fixture-3/a.css
@@ -1,0 +1,24 @@
+@import './recursive/b.css';
+
+@font-face {
+	src: url('./font.woff');
+}
+.implicit-sibling {
+	background-image: url("implicit-sibling.png");
+}
+.absolute {
+	background-image: url("http://example.com/absolute.png");
+}
+.root-relative {
+	background-image: url("/root-relative.png");
+}
+.sibling {
+	background-image: url("./sibling.png");
+}
+.parent {
+	background-image: url("../parent.png");
+}
+.grandparent {
+	background-image: url("../../grandparent.png");
+}
+

--- a/test/fixture-3/a.css
+++ b/test/fixture-3/a.css
@@ -1,7 +1,7 @@
 @import './recursive/b.css';
 
 @font-face {
-	src: url('./font.woff');
+	src: url("./font.woff");
 }
 .implicit-sibling {
 	background-image: url("implicit-sibling.png");

--- a/test/fixture-3/main.html
+++ b/test/fixture-3/main.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" type="text/css" href="style.css">

--- a/test/fixture-3/recursive/b.css
+++ b/test/fixture-3/recursive/b.css
@@ -1,5 +1,5 @@
 @font-face {
-	src: url('../font-recursive.woff');
+	src: url("../font-recursive.woff");
 }
 
 .sibling-recursive {

--- a/test/fixture-3/recursive/b.css
+++ b/test/fixture-3/recursive/b.css
@@ -1,0 +1,19 @@
+@font-face {
+	src: url('../font-recursive.woff');
+}
+
+.sibling-recursive {
+	background-image: url("./sibling-recursive.png");
+}
+
+.parent-recursive {
+	background-image: url("../parent-recursive.png");
+}
+
+.grandparent-recursive {
+	background-image: url("../../grandparent-recursive.png");
+}
+
+.absolute-recursive {
+	background-image: url("http://example.com/absolute-recursive.png");
+}

--- a/test/fixture-3/style.css
+++ b/test/fixture-3/style.css
@@ -1,0 +1,4 @@
+@import url(http://localhost:1234/fixture-3/a.css);
+.style {
+	content: ".style";
+}

--- a/test/test.js
+++ b/test/test.js
@@ -216,50 +216,69 @@ describe("recursive import", function() {
 
 	describe("fixture-3 convert relative paths in property values", function() {
 
+		it("does not resolve relative URLs by default", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'src: url("./font.woff");', {}, {}, done);
+		});
+
+		it("does not resolve relative URLs when option.resolveURLs is false", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'src: url("./font.woff");', { resolveUrls: false }, {}, done);
+		});
+
+		var _opts = { resolveUrls: true };
+
+		it("resolves relative URLs when option.resolveURLs is true", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'src: url("http://localhost:1234/fixture-3/font.woff");', _opts, {}, done);
+		});
+
 		it("does not modify absolute paths", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
-			testContains(input, 'background-image: url("http://example.com/absolute.png");', opts, {}, done);
+			testContains(input, 'background-image: url("http://example.com/absolute.png");', _opts, {}, done);
 		});
 
 		it("makes root relative paths absolute", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
-			testContains(input, 'background-image: url("http://localhost:1234/root-relative.png")', opts, {}, done);
+			testContains(input, 'background-image: url("http://localhost:1234/root-relative.png")', _opts, {}, done);
 		});
 
 		it("makes implicit sibling paths absolute", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
-			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/implicit-sibling.png")', opts, {}, done);
+			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/implicit-sibling.png")', _opts, {}, done);
 		});
 
 		it("makes relative sibling paths absolute", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
-			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/sibling.png")', opts, {}, done);
+			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/sibling.png")', _opts, {}, done);
 		});
 
 		it("makes parent relative paths absolute", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
-			testContains(input, 'background-image: url("http://localhost:1234/parent.png")', opts, {}, done);
+			testContains(input, 'background-image: url("http://localhost:1234/parent.png")', _opts, {}, done);
 		});
 
 		it("makes grandparent relative paths absolute", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
-			testContains(input, 'background-image: url("http://localhost:1234/grandparent.png")', opts, {}, done);
+			testContains(input, 'background-image: url("http://localhost:1234/grandparent.png")', _opts, {}, done);
 		});
+
+		var _optsRecursive = { resolveUrls: true, recursive: true };
 
 		// Test paths are resolved for recursively imported stylesheets
 		it("makes relative sibling paths absolute - recursive", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
-			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/recursive/sibling-recursive.png")', opts, {}, done);
+			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/recursive/sibling-recursive.png")', _optsRecursive, {}, done);
 		});
 
 		it("makes parent relative paths absolute - recursive", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
-			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/parent-recursive.png")', opts, {}, done);
+			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/parent-recursive.png")', _optsRecursive, {}, done);
 		});
 
 		it("makes grandparent relative paths absolute - recursive", function(done) {
 			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
-			testContains(input, 'background-image: url("http://localhost:1234/grandparent-recursive.png")', opts, {}, done);
+			testContains(input, 'background-image: url("http://localhost:1234/grandparent-recursive.png")', _optsRecursive, {}, done);
 		});
 
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -214,6 +214,56 @@ describe("recursive import", function() {
 		});
 	});
 
+	describe("fixture-3 convert relative paths in property values", function() {
+
+		it("does not modify absolute paths", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'background-image: url("http://example.com/absolute.png");', opts, {}, done);
+		});
+
+		it("makes root relative paths absolute", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'background-image: url("http://localhost:1234/root-relative.png")', opts, {}, done);
+		});
+
+		it("makes implicit sibling paths absolute", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/implicit-sibling.png")', opts, {}, done);
+		});
+
+		it("makes relative sibling paths absolute", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/sibling.png")', opts, {}, done);
+		});
+
+		it("makes parent relative paths absolute", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'background-image: url("http://localhost:1234/parent.png")', opts, {}, done);
+		});
+
+		it("makes grandparent relative paths absolute", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'background-image: url("http://localhost:1234/grandparent.png")', opts, {}, done);
+		});
+
+		// Test paths are resolved for recursively imported stylesheets
+		it("makes relative sibling paths absolute - recursive", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/recursive/sibling-recursive.png")', opts, {}, done);
+		});
+
+		it("makes parent relative paths absolute - recursive", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'background-image: url("http://localhost:1234/fixture-3/parent-recursive.png")', opts, {}, done);
+		});
+
+		it("makes grandparent relative paths absolute - recursive", function(done) {
+			var input = '@import url(http://localhost:1234/fixture-3/style.css)';
+			testContains(input, 'background-image: url("http://localhost:1234/grandparent-recursive.png")', opts, {}, done);
+		});
+
+	});
+
 });
 
 describe("google font woff", function() {


### PR DESCRIPTION
Hi @unlight, and thanks for this plugin!

I encountered a need for converting relative paths referenced in remote files to be absolute, as otherwise it the relative files would fail to resolve, and cause build issues down the pipeline.
Let me know if this PR is something you'd want to accept or not.
But for our use case, resolving assets paths to be absolute allows for chaining with other plugins to either download the assets or inline them as base64.

I've added tests which should illustrate the resolution better, but here's the idea:
``` css
/* myFile.css */
@import url("https://example.com/styles.css");
```

``` css
/* https://example.com/styles.css */
@font-family {
  src: url("./relative/path/font.woff");
}
```

**Output**
``` diff
/* myFile-compiled.css */
@font-family {
-  src: url("./relative/path/font.woff");
+  src: url("https://example.com/relative/path/font.woff");
}
```

---

One question though, I didn't put this functionality behind an option flag as I didn't think keeping asset paths relative would be a desirable very often, but I can see how that might be misconception on my part, or even a breaking change for some setups.
I'd appreciate your guidance on how, and if, you'd like this to work.

Thanks again 👋