### PR TITLE
Feature: support proxies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var postcss = require('postcss');
-var hh = require('http-https');
+var request = require('request');
 var isUrl = require('is-url');
 var trim = require('lodash.trim');
 var resolveRelative = require('resolve-relative-url');
@@ -11,7 +11,6 @@ var defaults = {
     userAgent: null,
 };
 var space = postcss.list.space;
-var url = require('url');
 var urlRegexp = /url\(["']?.+?['"]?\)/g;
 
 function postcssImportUrl(options) {
@@ -74,9 +73,12 @@ function resolveUrls(to, from) {
 }
 
 function createPromise(remoteFile, options) {
-    var reqOptions = url.parse(remoteFile);
-    reqOptions.headers = {};
-    reqOptions.headers['connection'] = 'keep-alive';
+    var reqOptions = {
+        url: remoteFile,
+        headers: {
+            connection: 'keep-alive',
+        },
+    };
     if (options.modernBrowser) {
         reqOptions.headers['user-agent'] =
             'Mozilla/5.0 AppleWebKit/538.0 Chrome/65.0.0.0 Safari/538';
@@ -85,20 +87,15 @@ function createPromise(remoteFile, options) {
         reqOptions.headers['user-agent'] = String(options.userAgent);
     }
     function executor(resolve, reject) {
-        var request = hh.get(reqOptions, function (response) {
-            var body = '';
-            response.on('data', function (chunk) {
-                body += chunk.toString();
-            });
-            response.on('end', function () {
-                resolve({
-                    body: body,
-                    parent: remoteFile,
-                });
+        request(remoteFile, reqOptions, function (error, response) {
+            if (error) {
+                return reject(error);
+            }
+            resolve({
+                body: response.body,
+                parent: remoteFile,
             });
         });
-        request.on('error', reject);
-        request.end();
     }
     return new Promise(executor);
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "node": ">=10"
   },
   "dependencies": {
-    "http-https": "^1.0.0",
     "is-url": "^1.2.4",
     "lodash.assign": "^4.2.0",
     "lodash.trim": "^4.5.1",
+    "request": "^2.88.2",
     "resolve-relative-url": "^1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Sadly this package currently fails to work for us behind a corporate proxy as `http-https` fails to pick up proxy settings from environment variables on the OS. The `request` package does this very well - so this is a simple swap out from `http-https` to `request`. Interface remains unchanged.