### PR TITLE
breaking: Update plugin to support PostCSS v8

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ var urlRegexp = /url\(["']?.+?['"]?\)/g;
 
 function postcssImportUrl(options) {
     options = assign({}, defaults, options || {});
-    return function importUrl(tree, dummy, parentRemoteFile) {
+
+    function importUrl(tree, dummy, parentRemoteFile) {
         parentRemoteFile = parentRemoteFile || tree.source.input.file;
         var imports = [];
         tree.walkAtRules('import', function checkAtRule(atRule) {
@@ -56,10 +57,16 @@ function postcssImportUrl(options) {
         return Promise.all(imports).then(function () {
             return tree;
         });
+    }
+
+    return {
+        postcssPlugin: 'postcss-import-url',
+        Once: importUrl,
     };
 }
 
-module.exports = postcss.plugin('postcss-import-url', postcssImportUrl);
+module.exports = postcssImportUrl;
+module.exports.postcss = true;
 
 function cleanupRemoteFile(value) {
     if (value.substr(0, 3) === 'url') {

--- a/package.json
+++ b/package.json
@@ -20,11 +20,10 @@
     "resolve-relative-url": "^1.0.0"
   },
   "peerDependencies": {
-    "postcss": ">=6 <8"
+    "postcss": "^8.0.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",
-    "postcss": ">=6 <8",
     "@semantic-release/git": "^9.0.0",
     "chai": "^4.2.0",
     "gulp": "^4.0.2",
@@ -32,6 +31,7 @@
     "gulp-eslint": "^6.0.0",
     "gulp-mocha": "^7.0.2",
     "husky": "^4.2.3",
+    "postcss": "^8.2.0",
     "precise-commits": "^1.0.2",
     "prettier": "^2.0.2",
     "semantic-release": "^17.0.4",


### PR DESCRIPTION
Hi @unlight, this PR makes the [basic changes](https://evilmartians.com/chronicles/postcss-8-plugin-migration) to get the plugin working with PostCSS v8. There is room for future performance improvements.

One question I have is with regards to the `Tangerine` tests.
These tests fail for me on my local machine, even with a fresh clone of the repository without any changes.
Would appreciate it if you could guide me on how you'd like me proceed with these tests: try to fix them, or ignore them for this PR.

Thanks!