### PR TITLE
feat: Add support for base64 encoded data urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See [PostCSS](https://github.com/postcss/postcss#usage) docs for examples for yo
 - `resolveUrls` (boolean) To transform relative URLs found in remote stylesheets into fully qualified URLs ([see #18](https://github.com/unlight/postcss-import-url/pull/18)) (default: `false`)
 - `modernBrowser` (boolean) Set user-agent string to 'Mozilla/5.0 AppleWebKit/537.36 Chrome/80.0.0.0 Safari/537.36', this option maybe useful for importing fonts from Google. Google check `user-agent` header string and respond can be different (default: `false`)
 - `userAgent` (string) Custom user-agent header (default: `null`)
+- `dataUrls` (boolean) Store fetched CSS as base64 encoded data URLs (default: `false`)
 
 ## Known Issues
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const defaults = {
   resolveUrls: false,
   modernBrowser: false,
   userAgent: null,
+  dataUrls: false,
 };
 const space = postcss.list.space;
 const urlRegexp = /url\(["']?.+?['"]?\)/g;
@@ -96,10 +97,15 @@ function postcssImportUrl(options) {
             );
           }
 
-          const tree = await (options.recursive
+          const importedTree = await (options.recursive
             ? importUrl(newNode, null, r.parent)
             : Promise.resolve(newNode));
-          atRule.replaceWith(tree);
+
+          if (options.dataUrls) {
+            atRule.params = `url(data:text/css;base64,${Buffer.from(importedTree.toString()).toString('base64')})`;
+          } else {
+            atRule.replaceWith(importedTree);
+          }
         },
       );
     });

--- a/test/test.js
+++ b/test/test.js
@@ -457,3 +457,11 @@ describe('source property', () => {
     expect(result.root.source.input.css).toEqual(input);
   });
 });
+
+describe('base64 data urls', function () {
+  it('option dataUrls should converts imports to base64 encoded data urls', async () => {
+    const input = '@import url(http://fonts.googleapis.com/css?family=Tangerine);';
+    const result = await getResult(input, { dataUrls: true });
+    expect(result.css.trim()).toEqual('@import url(data:text/css;base64,QGZvbnQtZmFjZSB7CiAgZm9udC1mYW1pbHk6ICdUYW5nZXJpbmUnOwogIGZvbnQtc3R5bGU6IG5vcm1hbDsKICBmb250LXdlaWdodDogNDAwOwogIHNyYzogdXJsKGh0dHA6Ly9mb250cy5nc3RhdGljLmNvbS9zL3RhbmdlcmluZS92MTcvSXVyWTZZNWpfb1NjWlpvdzRWT3hDWlpKLnR0ZikgZm9ybWF0KCd0cnVldHlwZScpOwp9Cg==);');
+  });
+});


### PR DESCRIPTION
Underlying issue :
- this plugin only handles remote urls
- `postcss-import` only handles local sources and only when `@import` statements are first and in order (following the CSS specification)

This makes it impossible to to use both plugins together without forcing a specific order of statements. Sometimes this forced order is not what is desired.

-----

This change adds the option to store imported CSS back into an `@import` statement, but as a data url.

```css
@import url(http://fonts.googleapis.com/css?family=Tangerine);
```

becomes :

```css
@import url(data:text/css;base64,QGZvbnQtZmFjZSB7CiAgZm9udC1mYW1pbHk6ICdUYW5nZXJpbmUnOwogIGZvbnQtc3R5bGU6IG5vcm1hbDsKICBmb250LXdlaWdodDogNDAwOwogIHNyYzogdXJsKGh0dHA6Ly9mb250cy5nc3RhdGljLmNvbS9zL3RhbmdlcmluZS92MTcvSXVyWTZZNWpfb1NjWlpvdzRWT3hDWlpKLnR0ZikgZm9ybWF0KCd0cnVldHlwZScpOwp9Cg==);
```

decoded :

```css
@font-face {
  font-family: 'Tangerine';
  font-style: normal;
  font-weight: 400;
  src: url(http://fonts.gstatic.com/s/tangerine/v17/IurY6Y5j_oScZZow4VOxCZZJ.ttf) format('truetype');
}
```

-------

Combined with support for data urls in `postcss-import` it allows users to be more creative with their setups and plugin combinations.