### PR TITLE
Use whatwg-url over deprecated url apis, and swap out http-https for axios

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 const postcss = require('postcss');
-const hh = require('http-https');
+const axios = require('axios');
 const isUrl = require('is-url');
 const trim = require('lodash.trim');
-const resolveRelative = require('resolve-relative-url');
 const assign = require('lodash.assign');
-const url = require('url');
 
 const defaults = {
     recursive: true,
@@ -25,7 +23,7 @@ function postcssImportUrl(options) {
             const params = space(atRule.params);
             let remoteFile = cleanupRemoteFile(params[0]);
             if (parentRemoteFile) {
-                remoteFile = resolveRelative(remoteFile, parentRemoteFile);
+                remoteFile = new URL(remoteFile, parentRemoteFile).href;
             }
             if (!isUrl(remoteFile)) {
                 return;
@@ -84,13 +82,16 @@ function cleanupRemoteFile(value) {
 }
 
 function resolveUrls(to, from) {
-    return 'url("' + resolveRelative(cleanupRemoteFile(to), from) + '")';
+    return 'url("' + new URL(cleanupRemoteFile(to), from).href + '")';
 }
 
 function createPromise(remoteFile, options) {
-    const reqOptions = urlParse(remoteFile);
-    reqOptions.headers = {};
-    reqOptions.headers['connection'] = 'keep-alive';
+    const reqOptions = {
+        url: remoteFile,
+        headers: {
+            connection: 'keep-alive',
+        },
+    };
     if (options.modernBrowser) {
         reqOptions.headers['user-agent'] =
             'Mozilla/5.0 AppleWebKit/538.0 Chrome/88.0.0.0 Safari/538';
@@ -99,25 +100,16 @@ function createPromise(remoteFile, options) {
         reqOptions.headers['user-agent'] = String(options.userAgent);
     }
     function executor(resolve, reject) {
-        const request = hh.get(reqOptions, response => {
-            let body = '';
-            response.on('data', chunk => {
-                body += chunk.toString();
-            });
-            response.on('end', () => {
+        axios(reqOptions)
+            .then(response => {
                 resolve({
-                    body: body,
+                    body: response.data,
                     parent: remoteFile,
                 });
+            })
+            .catch(error => {
+                return reject(error);
             });
-        });
-        request.on('error', reject);
-        request.end();
     }
     return new Promise(executor);
-}
-
-function urlParse(remoteFile) {
-    const reqOptions = url.parse(remoteFile);
-    return reqOptions;
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,10 @@
     "test:w": "gulp test:w"
   },
   "dependencies": {
-    "http-https": "^1.0.0",
+    "axios": "^1.4.0",
     "is-url": "^1.2.4",
     "lodash.assign": "^4.2.0",
-    "lodash.trim": "^4.5.1",
-    "resolve-relative-url": "^1.0.0"
+    "lodash.trim": "^4.5.1"
   },
   "peerDependencies": {
     "postcss": "^8.0.0"


### PR DESCRIPTION
- Removes deprecated url apis
- Fixes #25
- And Axios is supported in both node.js and browser.